### PR TITLE
1.9.2 break

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -2,7 +2,7 @@ $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/lib')
 
 use Rack::ShowExceptions
 
-require 'lib/git_http'
+require 'git_http'
 
 config = {
   :project_root => "/opt",


### PR DESCRIPTION
Fix in the config.ru file to allow grack to load on 1.9.2 without further edits

This isn't a complete assurance that grack works correctly on 1.9.2, but it does load.
