### PR TITLE
Shallow clone fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 coverage/
+.redcar

--- a/lib/git_http.rb
+++ b/lib/git_http.rb
@@ -66,6 +66,7 @@ class GitHttp
         command = git_command("#{@rpc} --stateless-rpc #{@dir}")
         IO.popen(command, File::RDWR) do |pipe|
           pipe.write(input)
+          pipe.close_write
           while !pipe.eof?
             block = pipe.read(8192) # 8M at a time
             @res.write block        # steam it to the client


### PR DESCRIPTION
This is a fix for issue #6.

Closing the pipe to the child process makes shallow cloning work. However the child process also prints out "fatal: The remote end hung up unexpectedly". This seems to be because the input to the process doesn't end in the packet line "0009done\n" as normal.

So I ran the shallow clone to Github through a proxy to compare and it seems that the requests and responses match up precisely, so I'm not sure if that error has any significance...
