### PR TITLE
strip trailing whitespace from default `pwd`-based project directory.

### DIFF
--- a/lib/git_http.rb
+++ b/lib/git_http.rb
@@ -169,7 +169,7 @@ class GitHttp
     end
 
     def get_git_dir(path)
-      root = @config[:project_root] || `pwd`.strip!
+      root = @config[:project_root] || Dir.pwd
       path = File.join(root, path)
       if File.exists?(path) # TODO: check is a valid git directory
         return path


### PR DESCRIPTION
`pwd` on some systems will return a path with a trailing newline. That results in an incorrect path resolution to the git repository.
