### PR TITLE
typo in the comment

### DIFF
--- a/lib/git_http.rb
+++ b/lib/git_http.rb
@@ -67,7 +67,7 @@ class GitHttp
         IO.popen(command, File::RDWR) do |pipe|
           pipe.write(input)
           while !pipe.eof?
-            block = pipe.read(8192) # 8M at a time
+            block = pipe.read(8192) # 8K at a time
             @res.write block        # steam it to the client
           end
         end


### PR DESCRIPTION
I've found the following typo in git_http.rb.

``` ruby
block = pipe.read(8192) # 8M at a time
```

I've fixed the comment to "8K", but did you mean to read 8MB (8388608 byets)?
